### PR TITLE
Make timestamps consistent

### DIFF
--- a/src/lemonade/cache.py
+++ b/src/lemonade/cache.py
@@ -1,5 +1,4 @@
 import os
-from datetime import datetime, timezone
 
 # Allow an environment variable to override the default
 # location for the build cache

--- a/src/lemonade/cache.py
+++ b/src/lemonade/cache.py
@@ -17,20 +17,17 @@ def checkpoint_to_model_name(checkpoint_name: str) -> str:
     return checkpoint_name.split("/")[1]
 
 
-def get_timestamp() -> str:
+def get_build_timestamp(build_time) -> str:
     """
     Get a timestamp string in the format:
         <year>y_<month>m_<day>d_<hour>h_<minute>m_<second>s
     """
-    # Get the current time in GMT
-    current_time = datetime.now(timezone.utc)
-
     # Format the timestamp string
-    timestamp = current_time.strftime("%Yy_%mm_%dd_%Hh_%Mm_%Ss")
+    timestamp = build_time.strftime("%Yy_%mm_%dd_%Hh_%Mm_%Ss")
     return timestamp
 
 
-def build_name(input_name):
+def build_name(input_name, build_time):
     """
     Name the lemonade build by concatenating these two factors:
         1. Sanitize the input name (typically a model checkpoint name) by
@@ -54,7 +51,7 @@ def build_name(input_name):
         input_name_sanitized = input_name_sanitized.replace(":", "-")
 
     # Get the formatted timestamp string
-    timestamp = get_timestamp()
+    timestamp = get_build_timestamp(build_time)
 
     return f"{input_name_sanitized}_{timestamp}"
 

--- a/src/lemonade/cli.py
+++ b/src/lemonade/cli.py
@@ -1,5 +1,6 @@
 import os
 import platform
+from datetime import datetime
 
 # pylint: disable=C0413
 # Prevent HF warnings from showing on every import
@@ -151,10 +152,12 @@ https://github.com/lemonade-sdk/lemonade/blob/main/docs/eval/README.md""",
         first_tool_args.append("--input")
         first_tool_args.append(global_args["input"])
 
+        build_time = datetime.now().astimezone()
         state = State(
             cache_dir=os.path.abspath(global_args["cache_dir"]),
-            build_name=cache.build_name(global_args["input"]),
+            build_name=cache.build_name(global_args["input"], build_time),
             sequence_info=sequence.info,
+            build_time=build_time,
         )
         sequence.launch(state)
     else:

--- a/src/lemonade/common/filesystem.py
+++ b/src/lemonade/common/filesystem.py
@@ -187,9 +187,13 @@ def get_available_builds(cache_dir):
 
     check_cache_dir(cache_dir)
 
+    builds_dir = os.path.abspath(build.builds_dir(cache_dir))
+    if not os.path.isdir(builds_dir):
+        return []
+
     builds = [
         pathlib.PurePath(build_name).name
-        for build_name in os.listdir(os.path.abspath(build.builds_dir(cache_dir)))
+        for build_name in os.listdir(builds_dir)
         if os.path.isdir(build.output_dir(cache_dir, build_name))
         and is_build_dir(cache_dir, build_name)
     ]
@@ -228,7 +232,7 @@ class Keys:
     # Prefix for reporting the execution status of a tool
     # In the report this will look like tool_status:TOOL_NAME
     TOOL_STATUS = "tool_status"
-    # Records the date and time of the evaluation after analysis but before
+    # Records the local date and time of the evaluation after analysis but before
     # build and benchmark
     TIMESTAMP = "timestamp"
     # Records the logfile of any failed tool/benchmark

--- a/src/lemonade/sequence.py
+++ b/src/lemonade/sequence.py
@@ -3,10 +3,8 @@ import time
 import os
 import platform
 import copy
-from datetime import datetime
 from typing import List, Dict, Optional
 
-import pytz
 import psutil
 
 import lemonade.common.printing as printing
@@ -115,8 +113,7 @@ class Sequence:
         Executes the sequence of tools.
         """
 
-        current_time = datetime.now()
-        timestamp = current_time.strftime("%Y-%m-%d-%H%M%S")
+        timestamp = state.build_time.strftime("%Y-%m-%d-%H%M%S")
         start_times = {"warmup": time.time()}
 
         # Allow monitor to be globally disabled by an environment variable
@@ -161,11 +158,7 @@ class Sequence:
         state.save_stat(fs.Keys.BUILD_STATUS, build.FunctionStatus.INCOMPLETE)
 
         # Save a timestamp so that we know the order of builds within a cache
-        pacific_tz = pytz.timezone("America/Los_Angeles")
-        state.save_stat(
-            fs.Keys.TIMESTAMP,
-            datetime.now(pacific_tz),
-        )
+        state.save_stat(fs.Keys.TIMESTAMP, state.build_time)
 
         # Save the system information used for this build
         system_info = build.get_system_info_from_server()

--- a/src/lemonade/state.py
+++ b/src/lemonade/state.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from datetime import datetime
 from typing import Dict, Optional, Any
 import yaml
 import lemonade.common.build as build
@@ -61,6 +62,7 @@ class State:
         cache_dir: str,
         build_name: Optional[str] = None,
         sequence_info: Dict[str, Dict] = None,
+        build_time: Optional[datetime] = None,
         **kwargs,
     ):
 
@@ -75,6 +77,9 @@ class State:
         self.cache_dir = parsed_cache_dir
         self.build_name = build_name
         self.sequence_info = sequence_info
+        self.build_time = (
+            datetime.now().astimezone() if build_time is None else build_time
+        )
         self.lemonade_version = lemonade_version
         self.build_status = build.FunctionStatus.NOT_STARTED
         self.downcast_applied = False

--- a/src/lemonade/tools/report/llm_report.py
+++ b/src/lemonade/tools/report/llm_report.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import re
 from typing import List
 import lemonade.common.printing as printing
+import lemonade.common.exceptions as exp
 import lemonade.common.filesystem as fs
 from lemonade.tools.management_tools import ManagementTool
 from lemonade.cache import DEFAULT_CACHE_DIR
@@ -148,7 +149,13 @@ class LemonadeReport(ManagementTool):
     ):
         # Process input arguments
         cache_dirs = [os.path.expanduser(dir) for dir in input_caches]
-        cache_dirs = fs.expand_inputs(cache_dirs)
+        try:
+            cache_dirs = fs.expand_inputs(cache_dirs)
+        except exp.ArgError as e:
+            printing.log_info(
+                f"No Lemonade cache folders exist for: {cache_dirs}. Error: {e}"
+            )
+            return
         report_dir = os.path.expanduser(output_dir)
 
         if perf:

--- a/src/lemonade/tools/report/table.py
+++ b/src/lemonade/tools/report/table.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from datetime import datetime, timezone
+from datetime import datetime
 import re
 from typing import Tuple, Dict, List
 import textwrap

--- a/src/lemonade/tools/report/table.py
+++ b/src/lemonade/tools/report/table.py
@@ -585,9 +585,10 @@ class Table(ABC):
         """
         Returns the name of the .csv report
         """
-        day = datetime.now().day
-        month = datetime.now().month
-        year = datetime.now().year
+        currentTime = datetime.now()
+        day = currentTime.day
+        month = currentTime.month
+        year = currentTime.year
         date_key = f"{year}-{str(month).zfill(2)}-{str(day).zfill(2)}"
         return f"{prefix}{date_key}.csv"
 
@@ -774,7 +775,7 @@ class LemonadePerfTable(Table):
         # Filter out build if it is too old
         if not self.days is None:
             build_day = model_stats[fs.Keys.TIMESTAMP]
-            today = datetime.now(timezone.utc)
+            today = datetime.now()
             delta = today - build_day
             if delta.days > self.days:
                 return False
@@ -891,7 +892,7 @@ class LemonadePerfTable(Table):
 
     @staticmethod
     def get_report_name() -> str:
-        current_time = datetime.now(timezone.utc)
+        current_time = datetime.now()
         timestamp = current_time.strftime("%Y-%m-%d-%H%M%S")
         return f"{timestamp}_perf.csv"
 


### PR DESCRIPTION
Per Issue #9, I've reviewed the timestamping behavior.  These changes:
1) Use a single build time taken at the launch of the run and now stored as part of the state.
2) Use local time for the build folder name (instead of UTC), making it much easier to find the appropriate build
3) The timestamp field of the stats file still contains the offset to UTC so absolute time can always be determined.

I also added one fix to exit cleanly if the Lemonade cache folder doesn't exist.

Closes #9 .